### PR TITLE
Catch error event from net module

### DIFF
--- a/node-rcon.js
+++ b/node-rcon.js
@@ -27,7 +27,7 @@ function Rcon(host, port, password, id) {
   this.socket = null;
   this.rconId = id || 0x0012D4A6;
   this.hasAuthed = false;
-  
+
   events.EventEmitter.call(this);
 };
 
@@ -36,7 +36,7 @@ util.inherits(Rcon, events.EventEmitter);
 Rcon.prototype.send = function(data, cmd, id) {
   cmd = cmd || PacketType.COMMAND;
   id = id || this.rconId;
-  
+
   var sendBuf = new Buffer(data.length + 16);
   sendBuf.writeInt32LE(data.length + 12, 0);
   sendBuf.writeInt32LE(id, 4);
@@ -51,6 +51,7 @@ Rcon.prototype.connect = function() {
   this.socket = net.createConnection(this.port, this.host);
   this.socket.on('data', function(data) { self.socketOnData(data) })
              .on('connect', function() { self.socketOnConnect() })
+             .on('error', function(err) { self.emit('error', err); })
              .on('end', function() { self.socketOnEnd() });
 };
 
@@ -61,7 +62,7 @@ Rcon.prototype.disconnect = function() {
 Rcon.prototype.socketOnData = function(data) {
   var len = data.readInt32LE(0);
   if (!len) return;
-  
+
   if (len >= 8 && data.readInt32LE(4) == this.rconId) {
     var packetType = data.readInt32LE(8);
     if (!this.hasAuthed && packetType == PacketType.RESPONSE_AUTH) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Justin Li <jli@j-li.net>",
   "name": "rcon",
   "description": "A generic RCON client for nodejs.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/j1i/node-rcon",
   "repository": "git://github.com/j1i/node-rcon",
   "main": "node-rcon",


### PR DESCRIPTION
I add a listener on error event sent by net module.
It fires a new error event that can be catched by the user of the rcon module as the other events.

Signed-off-by: Emilien Kenler hello@emilienkenler.com
