### PR TITLE
fix an Issue when more then one RCON-pakets are in data-buffer

### DIFF
--- a/node-rcon.js
+++ b/node-rcon.js
@@ -68,27 +68,28 @@ Rcon.prototype.setTimeout = function(timeout, callback) {
 };
 
 Rcon.prototype.socketOnData = function(data) {
- 	while(data.length > 0){
-   	var len  = data.readInt32LE(0);
-   	if (!len) return;
- 		var id   = data.readInt32LE(4);
- 		var type = data.readInt32LE(8);
- 		if (len >= 10 && id == this.rconId){
- 			if (!this.hasAuthed && type == PacketType.RESPONSE_AUTH){
- 				this.hasAuthed = true;
- 				this.emit('auth');
- 			}else if (type == PacketType.RESPONSE_VALUE){
-				/*	Read only "body" of one RCON-Packet (truncate 0x00 at the end) 
-				 *  See https://developer.valvesoftware.com/wiki/Source_RCON_Protocol for details
-				 */	
-       	var str = data.toString('utf8', 12, 12 + len - 10);
-				// emit the response without the 0x0a newline.
-       	this.emit('response', str.substring(0, str.length - 1));
- 			}
- 		}
- 		data = data.slice(12+len-8);
-  	}
- }; 
+  while(data.length > 0){
+    var len  = data.readInt32LE(0);
+    if (!len) return;
+    var id   = data.readInt32LE(4);
+    var type = data.readInt32LE(8);
+    if (len >= 10 && id == this.rconId){
+      if (!this.hasAuthed && type == PacketType.RESPONSE_AUTH){
+        this.hasAuthed = true;
+        this.emit('auth');
+      }else if (type == PacketType.RESPONSE_VALUE){
+        /* Read only "body" of one RCON-Packet (truncate 0x00 at the end) 
+         * See https://developer.valvesoftware.com/wiki/Source_RCON_Protocol for details
+         */	
+        var str = data.toString('utf8', 12, 12 + len - 10);
+        // emit the response without the 0x0a newline.
+       this.emit('response', str.substring(0, str.length - 1));
+      }
+    }
+    //delete handled packet.
+    data = data.slice(12+len-8);
+  }
+}; 
 
 Rcon.prototype.socketOnConnect = function() {
   this.send(this.password, PacketType.AUTH);


### PR DESCRIPTION
hi pushrax,

thanks for your work. You helped me so I want to help you ;-)

in **socketOnData** you handle each buffer as only one RCON-packet. 
When you have for example logging enabled you can have multiple packets in the buffer, so the line

``` javascript
var str = data.toString('utf8', 12);
```

cuts the header of the first RCON-Packet but dont touch the headers of the other packets in buffer and emit the packets as one big packet.

This fix read the structure of the RCON-Packets descriped on https://developer.valvesoftware.com/wiki/Source_RCON_Protocol 
and splits the buffer in single packets.

lg 

fastrde
