### PR TITLE
Corrects writeUint8 lowercase typo

### DIFF
--- a/node-rcon.js
+++ b/node-rcon.js
@@ -184,7 +184,7 @@ Rcon.prototype.socketOnConnect = function() {
   } else {
     var sendBuf = new Buffer(5);
     sendBuf.writeInt32LE(-1, 0);
-    sendBuf.writeUint8(0, 4);
+    sendBuf.writeUInt8(0, 4);
     this._sendSocket(sendBuf);
 
     this.hasAuthed = true;


### PR DESCRIPTION
`writeUint8` fails on my macbook with node 0.10.12.  Changing the case to `writeUInt8` seems to correct the problem.
