### PR TITLE
Reconnecting causes emit('auth') not to be called

### DIFF
--- a/node-rcon.js
+++ b/node-rcon.js
@@ -194,6 +194,7 @@ Rcon.prototype.socketOnConnect = function() {
 
 Rcon.prototype.socketOnEnd = function() {
   this.emit('end');
+  this.hasAuthed = false;
 };
 
 module.exports = Rcon;


### PR DESCRIPTION
I'm not sure if this object is meant to be reused after failure. If it is used that way, it fails to cause an auth event the second time.